### PR TITLE
Upgrade to Scala IDE 4.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .cache
+.cache-main

--- a/com.github.dnadolny.javatoscala.tests/META-INF/MANIFEST.MF
+++ b/com.github.dnadolny.javatoscala.tests/META-INF/MANIFEST.MF
@@ -5,11 +5,10 @@ Bundle-SymbolicName: com.github.dnadolny.javatoscala.tests
 Bundle-Version: 1.2.0.qualifier
 Bundle-Vendor: Donny Nadolny
 Fragment-Host: com.github.dnadolny.javatoscala
-Bundle-RequiredExecutionEnvironment: J2SE-1.5
-Require-Bundle: org.scala-ide.scala.library,
+Bundle-RequiredExecutionEnvironment: JavaSE-1.6
+Require-Bundle: org.scala-lang.scala-library,
  org.eclipse.equinox.weaving.aspectj,
- org.junit4;bundle-version="4.5.0",
- org.scala-ide.sdt.core
-Import-Package: scala.tools.eclipse.testsetup,
+ org.junit
+Import-Package: org.scalaide.core.testsetup,
  org.aspectj.weaver.loadtime.definition
 Bundle-ClassPath: .

--- a/com.github.dnadolny.javatoscala/.classpath
+++ b/com.github.dnadolny.javatoscala/.classpath
@@ -8,6 +8,6 @@
 	<classpathentry kind="lib" path="target/dependency/commons-io-1.3.2.jar"/>
 	<classpathentry kind="lib" path="target/dependency/commons-lang3-3.0.1.jar"/>
 	<classpathentry kind="lib" path="target/dependency/javaparser-1.0.10.jar"/>
-	<classpathentry kind="lib" path="target/lib/scalagen-0.3.2_scala-version.jar"/>
+	<classpathentry kind="lib" path="target/lib/scalagen-0.3.3_scala-version.jar"/>
 	<classpathentry kind="output" path="target/classes"/>
 </classpath>

--- a/com.github.dnadolny.javatoscala/META-INF/MANIFEST.MF
+++ b/com.github.dnadolny.javatoscala/META-INF/MANIFEST.MF
@@ -21,17 +21,17 @@ Require-Bundle:
  org.eclipse.ui.editors,
  org.eclipse.ui.forms,
  org.eclipse.ui.ide,
- org.scala-ide.scala.library,
- org.scala-ide.scala.compiler,
- org.scala-ide.sdt.core
+ org.scala-lang.scala-library;bundle-version="[2.11,2.12)",
+ org.scala-lang.scala-compiler;bundle-version="[2.11,2.12)",
+ org.scala-lang.scala-reflect;bundle-version="[2.11,2.12)",
+ org.scala-ide.sdt.core;bundle-version="[4.0.0,5.0.0)"
 Import-Package: 
  com.ibm.icu.text;apply-aspects:=false;org.eclipse.swt.graphics;apply-aspects:=false,
- scala.tools.eclipse;apply-aspects:=false,
  scala.tools.eclipse.contribution.weaving.jdt.ui.javaeditor.formatter;apply-aspects:=false
-Bundle-RequiredExecutionEnvironment: J2SE-1.5
+Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Bundle-Activator: com.github.dnadolny.javatoscala.JavaToScalaPlugin
 Bundle-ClassPath: .,
- target/lib/scalagen-0.3.2_scala-version.jar,
+ target/lib/scalagen-0.3.3_scala-version.jar,
  target/dependency/javaparser-1.0.10.jar,
  target/dependency/commons-lang3-3.0.1.jar,
  target/dependency/collections-generic-4.01.jar,

--- a/com.github.dnadolny.javatoscala/build.properties
+++ b/com.github.dnadolny.javatoscala/build.properties
@@ -5,7 +5,7 @@ bin.includes = META-INF/,\
                .,\
                plugin.xml,\
                plugin.properties,\
-               target/lib/scalagen-0.3.2_scala-version.jar,\
+               target/lib/scalagen-0.3.3_scala-version.jar,\
                target/dependency/javaparser-1.0.10.jar,\
                target/dependency/commons-lang3-3.0.1.jar,\
                target/dependency/collections-generic-4.01.jar,\

--- a/com.github.dnadolny.javatoscala/pom.xml
+++ b/com.github.dnadolny.javatoscala/pom.xml
@@ -9,12 +9,12 @@
   </parent>
   <artifactId>com.github.dnadolny.javatoscala</artifactId>
   <packaging>eclipse-plugin</packaging>
-  
+
   <dependencies>
     <dependency>
       <groupId>com.mysema.scalagen</groupId>
-      <artifactId>scalagen_${scala.version}</artifactId>
-      <version>0.3.2</version>
+      <artifactId>scalagen_${scala.version.short}</artifactId>
+      <version>0.3.3</version>
     </dependency>
   </dependencies>
 
@@ -35,9 +35,9 @@
               <artifactItems>
                 <artifactItem>
                   <groupId>com.mysema.scalagen</groupId>
-                  <artifactId>scalagen_${scala.version}</artifactId>
+                  <artifactId>scalagen_${scala.version.short}</artifactId>
                   <outputDirectory>${project.build.directory}/lib</outputDirectory>
-                  <destFileName>scalagen-0.3.2_scala-version.jar</destFileName>
+                  <destFileName>scalagen-0.3.3_scala-version.jar</destFileName>
                 </artifactItem>
                 <artifactItem>
                   <groupId>com.google.code.javaparser</groupId>

--- a/com.github.dnadolny.javatoscala/src/com/github/dnadolny/javatoscala/JavaToScalaImages.scala
+++ b/com.github.dnadolny.javatoscala/src/com/github/dnadolny/javatoscala/JavaToScalaImages.scala
@@ -3,10 +3,9 @@ package com.github.dnadolny.javatoscala
 import java.net.MalformedURLException
 import java.net.URL
 
-import scala.tools.eclipse.ScalaImages
-
 import org.eclipse.core.runtime.Platform
 import org.eclipse.jface.resource.ImageDescriptor
+import org.scalaide.ui.ScalaImages
 
 object JavaToScalaImages {
   val Error = create("icons/full/obj16/error_obj.gif")

--- a/com.github.dnadolny.javatoscala/src/com/github/dnadolny/javatoscala/convertsnippet/PasteJavaAsScalaCommand.scala
+++ b/com.github.dnadolny.javatoscala/src/com/github/dnadolny/javatoscala/convertsnippet/PasteJavaAsScalaCommand.scala
@@ -8,9 +8,9 @@ import org.eclipse.swt.dnd.Clipboard
 import org.eclipse.swt.dnd.TextTransfer
 import org.eclipse.swt.widgets.Display
 import org.eclipse.text.edits.ReplaceEdit
-import org.eclipse.ui.handlers.HandlerUtil
 import org.eclipse.ui.PlatformUI
-import org.scalaide.ui.internal.editor.ScalaSourceFileEditor
+import org.eclipse.ui.handlers.HandlerUtil
+import org.eclipse.ui.texteditor.ITextEditor
 
 import com.github.dnadolny.javatoscala.conversion.ConversionSuccess
 import com.github.dnadolny.javatoscala.conversion.MultiConversionFailure
@@ -42,7 +42,7 @@ class PasteJavaAsScalaCommand(snippetConverter: SnippetConverter) extends Abstra
 
   override def execute(event: ExecutionEvent): Object = {
     HandlerUtil.getActiveEditor(event) match {
-      case editor: ScalaSourceFileEditor =>
+      case editor: ITextEditor =>
         val text = getClipboardText()
         val document = editor.getDocumentProvider().getDocument(editor.getEditorInput)
         val textSelection = editor.getSelectionProvider().getSelection.asInstanceOf[TextSelection]
@@ -68,10 +68,8 @@ class PasteJavaAsScalaCommand(snippetConverter: SnippetConverter) extends Abstra
             val window = PlatformUI.getWorkbench.getActiveWorkbenchWindow
             new ConvertSnippetErrorDialog(window.getShell, failure).open()
         }
-      case _ => MessageDialog.openError(null, "Error converting Java to Scala", "Couldn't cast the editor to ScalaSourceFileEditor. This should never happen since the plugin.xml won't enable the menu item unless we're in a Scala editor")
+      case _ => MessageDialog.openError(null, "Error converting Java to Scala", "Couldn't cast the editor to ITextEditor. This should never happen since the plugin.xml won't enable the menu item unless we're in a Scala editor")
     }
     null
   }
-  
-
 }

--- a/com.github.dnadolny.javatoscala/src/com/github/dnadolny/javatoscala/convertsnippet/PasteJavaAsScalaCommand.scala
+++ b/com.github.dnadolny.javatoscala/src/com/github/dnadolny/javatoscala/convertsnippet/PasteJavaAsScalaCommand.scala
@@ -1,7 +1,5 @@
 package com.github.dnadolny.javatoscala.convertsnippet
 
-import scala.tools.eclipse.ScalaSourceFileEditor
-
 import org.eclipse.core.commands.AbstractHandler
 import org.eclipse.core.commands.ExecutionEvent
 import org.eclipse.jface.dialogs.MessageDialog
@@ -12,6 +10,7 @@ import org.eclipse.swt.widgets.Display
 import org.eclipse.text.edits.ReplaceEdit
 import org.eclipse.ui.handlers.HandlerUtil
 import org.eclipse.ui.PlatformUI
+import org.scalaide.ui.internal.editor.ScalaSourceFileEditor
 
 import com.github.dnadolny.javatoscala.conversion.ConversionSuccess
 import com.github.dnadolny.javatoscala.conversion.MultiConversionFailure

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
   <parent>
     <groupId>org.scala-ide</groupId>
     <artifactId>plugin-profiles</artifactId>
-    <version>1.0.8</version>
+    <version>1.0.10</version>
   </parent>
 
   <modules>

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
   <parent>
     <groupId>org.scala-ide</groupId>
     <artifactId>plugin-profiles</artifactId>
-    <version>1.0.1</version>
+    <version>1.0.8</version>
   </parent>
 
   <modules>


### PR DESCRIPTION
At the moment this uses an unreleased version of [scalagen](https://github.com/mysema/scalagen/), version 0.3.3 which adds scala 2.11 support. To try this out, first create a local copy of the new version of scalagen:

```
git clone https://github.com/mysema/scalagen.git
cd scalagen/scalagen
sed -i .bak 's|<version>0.3.2</version>|<version>0.3.3</version>|g' pom.xml
mvn -Pscala-2.11.x -Dmaven.test.skip=true install
```

Then, run one of:

```
#For Eclipse Kepler (4.3)
mvn -Pscala-2.11.x,eclipse-kepler,scala-ide-dev install

#For Eclipse Luna (4.4)
mvn -Pscala-2.11.x,eclipse-luna,scala-ide-dev install
```

This addresses #12 

@dragos, could you take a look? I've got it working, but I'm using the internal class `org.scalaide.ui.internal.editor.ScalaSourceFileEditor`. I'm not sure what I should do about that.
Additionally, I can only build using the profiles `scala-ide-dev` or `scala-ide-nightly`, not `scala-ide-stable` since in [plugin-profiles pom.xml](https://github.com/scala-ide/plugin-profiles/blob/master/pom.xml#L232) `scala-ide-stable` uses the `helium` path which ends up pointing to the Scala IDE v3.x, rather than `lithium` which is v4.0 now. Should the plugin profile be updated so that stable links to `lithium` (which is what http://scala-ide.org/download/current.html links to at the moment)?
